### PR TITLE
Default PgSQL charset to utf8

### DIFF
--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -714,7 +714,7 @@ class Api
                     'database' => $dbConfig['name'],
                     'username' => $dbConfig['user'] ?? '',
                     'password' => $dbConfig['pass'] ?? '',
-                    'charset' => $dbConfig['type'] === 'mysql' ? 'utf8mb4' : 'utf8',
+                    'charset' => ($dbConfig['type'] === 'mysql') ? 'utf8mb4' : 'utf8',
                     'collation' => 'utf8mb4_unicode_ci',
                     'prefix' => '',
                 ]);

--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -714,7 +714,7 @@ class Api
                     'database' => $dbConfig['name'],
                     'username' => $dbConfig['user'] ?? '',
                     'password' => $dbConfig['pass'] ?? '',
-                    'charset' => 'utf8mb4',
+                    'charset' => $dbConfig['type'] === 'pgsql' ? 'utf8' : 'utf8mb4',
                     'collation' => 'utf8mb4_unicode_ci',
                     'prefix' => '',
                 ]);

--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -714,7 +714,7 @@ class Api
                     'database' => $dbConfig['name'],
                     'username' => $dbConfig['user'] ?? '',
                     'password' => $dbConfig['pass'] ?? '',
-                    'charset' => $dbConfig['type'] === 'pgsql' ? 'utf8' : 'utf8mb4',
+                    'charset' => $dbConfig['type'] === 'mysql' ? 'utf8mb4' : 'utf8',
                     'collation' => 'utf8mb4_unicode_ci',
                     'prefix' => '',
                 ]);

--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -715,7 +715,7 @@ class Api
                     'username' => $dbConfig['user'] ?? '',
                     'password' => $dbConfig['pass'] ?? '',
                     'charset' => ($dbConfig['type'] === 'mysql') ? 'utf8mb4' : 'utf8',
-                    'collation' => 'utf8mb4_unicode_ci',
+                    'collation' => ($dbConfig['type'] === 'mysql') ? 'utf8mb4_unicode_ci' : null,
                     'prefix' => '',
                 ]);
         }


### PR DESCRIPTION
This would fit 99% of use case for #9 as almost all of us doesn't pay attention to the charset when creating a database or the default just fit what we need.