### PR TITLE
Handle empty DB username/password better

### DIFF
--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -386,11 +386,11 @@ class Api
             } else {
                 $this->rewriter->toFile($this->workDir('config/database.php'), [
                     'default' => $dbConfig['type'],
-                    'connections.' . $dbConfig['type'] . '.host' => $dbConfig['host'],
-                    'connections.' . $dbConfig['type'] . '.port' => $dbConfig['port'],
+                    'connections.' . $dbConfig['type'] . '.host' => $dbConfig['host'] ?? null,
+                    'connections.' . $dbConfig['type'] . '.port' => $dbConfig['port'] ?? $this->getDefaultDbPort($dbConfig['type']),
                     'connections.' . $dbConfig['type'] . '.database' => $dbConfig['name'],
-                    'connections.' . $dbConfig['type'] . '.username' => $dbConfig['user'],
-                    'connections.' . $dbConfig['type'] . '.password' => $dbConfig['pass'],
+                    'connections.' . $dbConfig['type'] . '.username' => $dbConfig['user'] ?? '',
+                    'connections.' . $dbConfig['type'] . '.password' => $dbConfig['pass'] ?? ''
                 ]);
             }
         } catch (\Throwable $e) {


### PR DESCRIPTION
This fix #14,
it reflects the capsule's default from here: https://github.com/wintercms/web-installer/blob/789fbdd4d9c6d15c4ceeb565c729f228dc2c768f/public/install/api/src/Api.php#L721-L732