### PR TITLE
Add proc_open function check

### DIFF
--- a/public/install/api/src/Api.php
+++ b/public/install/api/src/Api.php
@@ -146,6 +146,12 @@ class Api
      */
     public function getCheckPhpExtensions()
     {
+        $this->log->notice('Checking PHP "proc_open" function');
+        if (!function_exists('proc_open')) {
+            $this->data['extension'] = 'proc_open function';
+            $this->error('Missing function');
+        }
+
         $this->log->notice('Checking PHP "curl" extension');
         if (!function_exists('curl_init') || !defined('CURLOPT_FOLLOWLOCATION')) {
             $this->data['extension'] = 'curl';


### PR DESCRIPTION
As this seems to be the cause of most of the trouble for the webinstaller on shared hosting ( [as mentioned here](https://github.com/wintercms/web-installer/issues/18#issuecomment-898912895) by @bennothommo ), this adds a check for the availability of the `proc_open` php function during the extensions check.